### PR TITLE
Updated link for Todo.txt Enyo download

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
 					<h3>Mobile</h3>
 					<h4><a href="http://www.windowsphone.com/en-US/apps/50b1ca07-7e23-4963-a0ba-1536e6913543">Todo.txt for Windows Phone 7</a></h4>
 					<p>Todo.txt for Windows Phone 7 is a task manager based on the todo.txt file format, by <a href="https://github.com/hartez">E.Z. Hart</a>.</p>
-					<h4><a href="https://developer.palm.com/appredirect/?packageid=com.monkeystew.todotxtenyo.beta">Todo.txt Enyo</a></h4>
+					<h4><a href="http://monkeystew.org/apps/">Todo.txt Enyo</a></h4>
 					<p>A webOS application for managing your todo.txt file written using the EnyoJS framework, by <a href="https://github.com/thrrgilag">thrrgilag</a>.</p>
 					<h3>Developer Tools</h3>
 					<h4><a href="https://github.com/samwho/todo-txt-gem">Todo.txt Gem</a></h4>


### PR DESCRIPTION
Current link refers to the old HP app catalog where it is no longer available. This updated link refers back to my site where they can get the latest package updates.