### PR TITLE
enable setting of TODO_DIR via .profile,.bash_profile,.bashrc

### DIFF
--- a/todo.cfg
+++ b/todo.cfg
@@ -4,6 +4,14 @@
 #export TODO_DIR="/Users/gina/Documents/todo"
 export TODO_DIR=$(dirname "$0")
 
+if [ -f ~/.bash_profile ]; then
+	. ~/.bash_profile
+elif [ -f ~/.profile ]; then
+	. ~/.profile
+elif [ -f ~/.bashrc ]; then
+	. ~/.bashrc
+fi
+
 # Your todo/done/report.txt locations
 export TODO_FILE="$TODO_DIR/todo.txt"
 export DONE_FILE="$TODO_DIR/done.txt"


### PR DESCRIPTION
Currently setting this via any of these files doesn't change the location of my TODO_DIR. I'm wanting to change this location so that it syncs with the android client using dropbox