### PR TITLE
changing $TODO_SH => $TODO_FULL_SH

### DIFF
--- a/.todo.actions.d/adda
+++ b/.todo.actions.d/adda
@@ -12,9 +12,9 @@ shift
   exit
 }
 
-if "$TODO_SH" command add "$@"; then
+if "$TODO_FULL_SH" command add "$@"; then
     # figure out the line of what we just added, and prioritize it A
     line=`sed -n '$ =' "$TODO_FILE"`
     echo "$line"
-    "$TODO_SH" command pri "$line" A 
+    "$TODO_FULL_SH" command pri "$line" A 
 fi


### PR DESCRIPTION
 $TODO_SH env var points to a filename which is todo.sh, where it's better to have a full path with $TODO_FULL_SH. For those who have todo.sh in a custom location will run into: a "command not found" error at line 29.

 $TODO_SH = $(basename full/path/to/todo.sh) => todo.sh